### PR TITLE
In /say_alias, check if case number is found

### DIFF
--- a/AdiIRC/aliases.ini
+++ b/AdiIRC/aliases.ini
@@ -430,6 +430,11 @@ alias say_alias {
   if (%caseTracker == $true) {
     /findClientNames %params
     set %clientNames $result
+    
+    if ($isnumber(%clientNames)) {
+      echo -ag == Warning - Case %clientNames not found ==
+      return
+    }
 
     /findOdy $$3
     set %ody $result

--- a/mIRC/aliases.ini
+++ b/mIRC/aliases.ini
@@ -430,6 +430,11 @@
   if (%caseTracker == $true) {
     /findClientNames %params
     set %clientNames $result
+    
+    if ($isnumber(%clientNames)) {
+      echo -ag == Warning - Case %clientNames not found ==
+      return
+    }
 
     /findOdy $$3
     set %ody $result


### PR DESCRIPTION
When using CaseTracker and a number in a /say_alias, this will prevent a message from being written if the case does not exist in the list of cases, and instead shows a warning.

To bypass this, a Dispatcher can write the client's name in the alias instead of the case number. Or the dispatcher can use /addcase to create the missing case.

This change does not currently work when using multiple cases in a single alias, all of which do not exist. The old behavior will be observed with numbers being printed in the message.