### PR TITLE
Added NotFound check to /close

### DIFF
--- a/AdiIRC/aliases.ini
+++ b/AdiIRC/aliases.ini
@@ -922,8 +922,9 @@ alias close_main {
     /getClientNames $$2
     /set %client $result
 
-    if (%client isnum) {
-      /set %client $$4
+    if ($isnumber(%client)) {
+      echo -ag == Warning - Case %client not found ==
+      return
     }
   }
   else {

--- a/mIRC/aliases.ini
+++ b/mIRC/aliases.ini
@@ -922,8 +922,9 @@
     /getClientNames $$2
     /set %client $result
 
-    if (%client isnum) {
-      /set %client $$4
+    if ($isnumber(%clientNames)) {
+      echo -ag == Warning - Case %clientNames not found ==
+      return
     }
   }
   else {


### PR DESCRIPTION
Same check that I added for /say_alias when a case number is not found. When using CaseTracker™ not finding a case is almost always a typo, or the case wasn't created yet internally. Dispatcher can always supply the client name to avoid sending a bad "hang out with your rat" message.