### PR TITLE
prevent !close case clientnick

### DIFF
--- a/AdiIRC/aliases.ini
+++ b/AdiIRC/aliases.ini
@@ -959,6 +959,11 @@ alias close_main {
       return
     }
 
+    if ( %client == $$3 ) {
+      echo -ag == Warning - Can't close case to client ==
+      return
+    }
+
     if (%language == a) {
       /getLanguage %caseNum
       set %language $result

--- a/AdiIRC/aliases.ini
+++ b/AdiIRC/aliases.ini
@@ -959,7 +959,7 @@ alias close_main {
       return
     }
 
-    if ( %client == $$3 ) {
+    if ( %client == %rat ) {
       echo -ag == Warning - Can't close case to client ==
       return
     }

--- a/mIRC/aliases.ini
+++ b/mIRC/aliases.ini
@@ -959,7 +959,7 @@
       return
     }
 
-    if ( %client == $$3 ) {
+    if ( %client == %rat ) {
       echo -ag == Warning - Can't close case to client ==
       return
     }

--- a/mIRC/aliases.ini
+++ b/mIRC/aliases.ini
@@ -959,6 +959,11 @@
       return
     }
 
+    if ( %client == $$3 ) {
+      echo -ag == Warning - Can't close case to client ==
+      return
+    }
+
     if (%language == a) {
       /getLanguage %caseNum
       set %language $result


### PR DESCRIPTION
Added another sanity check in the /close_main alias. If you accidentally try to close the case and set the client's name as the rat, this will prevent any embarrassment.